### PR TITLE
Add docker compose for Kafka instance

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,10 +17,23 @@ services:
       # Broker setup
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:19092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+    healthcheck:
+      test:
+        [
+          'CMD',
+          '/opt/kafka/bin/kafka-topics.sh',
+          '--bootstrap-server',
+          'localhost:9092',
+          '--list',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   broker-2:
     image: apache/kafka:latest
     container_name: broker-2
+    restart: unless-stopped
     ports:
           - 29092:9092
     environment:
@@ -35,10 +48,25 @@ services:
       # Broker setup
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:29092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+    healthcheck:
+      test:
+        [
+          'CMD',
+          '/opt/kafka/bin/kafka-topics.sh',
+          '--bootstrap-server',
+          'localhost:9092',
+          '--list',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   akhq:
       image: tchiotludo/akhq
       restart: unless-stopped
+    depends_on:
+      - broker-1
+      - broker-2
       environment:
         AKHQ_CONFIGURATION: |
           akhq:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,67 +1,50 @@
 services:
-  controller:
-    image: apache/kafka:latest
-    container_name: controller-1
-    environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: controller
-      KAFKA_LISTENERS: CONTROLLER://:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller-1:9093,2@controller-2:9093,3@controller-3:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-
-
   broker-1:
     image: apache/kafka:latest
     container_name: broker-1
+    restart: unless-stopped
     ports:
-      - 29092:9092
+          - 19092:9092
     environment:
-      KAFKA_NODE_ID: 2
-      KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:29092'
+      # Shared setup
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092,CONTROLLER://:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller:9093
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker-1:9093,2@broker-2:9093
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    depends_on:
-      - controller
+      # Broker setup
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-1:19092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
 
   broker-2:
     image: apache/kafka:latest
     container_name: broker-2
     ports:
-      - 39092:9092
+          - 29092:9092
     environment:
-      KAFKA_NODE_ID: 3
-      KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:39092'
+      # Shared setup
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:19092,PLAINTEXT_HOST://:9092,CONTROLLER://:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller:9093
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker-1:9093,2@broker-2:9093
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    depends_on:
-      - controller
+      # Broker setup
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker-2:19092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
 
-  broker-3:
-    image: apache/kafka:latest
-    container_name: broker-3
-    ports:
-      - 49092:9092
-    environment:
-      KAFKA_NODE_ID: 6
-      KAFKA_PROCESS_ROLES: broker
-      KAFKA_LISTENERS: 'PLAINTEXT://:19092,PLAINTEXT_HOST://:9092'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker-3:19092,PLAINTEXT_HOST://localhost:49092'
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@controller:9093
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    depends_on:
-      - controller
+  akhq:
+      image: tchiotludo/akhq
+      restart: unless-stopped
+      environment:
+        AKHQ_CONFIGURATION: |
+          akhq:
+            connections:
+              docker-kafka-server:
+                properties:
+                  bootstrap.servers: "broker-1:19092,broker-2:19092"
+      ports:
+        - 8080:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: broker-1
     restart: unless-stopped
     ports:
-          - 19092:9092
+      - 19092:9092
     environment:
       # Shared setup
       KAFKA_NODE_ID: 1
@@ -35,7 +35,7 @@ services:
     container_name: broker-2
     restart: unless-stopped
     ports:
-          - 29092:9092
+      - 29092:9092
     environment:
       # Shared setup
       KAFKA_NODE_ID: 2
@@ -61,18 +61,37 @@ services:
       timeout: 5s
       retries: 5
 
-  akhq:
-      image: tchiotludo/akhq
-      restart: unless-stopped
+  init-topics:
+    image: apache/kafka:latest
     depends_on:
       - broker-1
       - broker-2
-      environment:
-        AKHQ_CONFIGURATION: |
-          akhq:
-            connections:
-              docker-kafka-server:
-                properties:
-                  bootstrap.servers: "broker-1:19092,broker-2:19092"
-      ports:
-        - 8080:8080
+    environment:
+      BOOTSTRAP_SERVERS: broker-1:19092
+    entrypoint: >
+      bash -c '
+        echo "Waiting for Kafka to be ready...";
+        for i in {1..30}; do
+          /opt/kafka/bin/kafka-topics.sh --bootstrap-server broker-1:19092 --list && break || sleep 2;
+        done;
+        echo "Creating topics...";
+        /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --bootstrap-server broker-1:19092 --topic Client --partitions 2 --replication-factor 2 &&
+        /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --bootstrap-server broker-1:19092 --topic Product --partitions 2 --replication-factor 2 &&
+        /opt/kafka/bin/kafka-topics.sh --create --if-not-exists --bootstrap-server broker-1:19092 --topic Command --partitions 2 --replication-factor 2;
+        echo "Kafka initialization complete.";'
+
+  akhq:
+    image: tchiotludo/akhq
+    restart: unless-stopped
+    depends_on:
+      - broker-1
+      - broker-2
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            docker-kafka-server:
+              properties:
+                bootstrap.servers: "broker-1:19092,broker-2:19092"
+    ports:
+      - 8080:8080


### PR DESCRIPTION
This pull request includes significant changes to the `docker-compose.yaml` file to streamline the Kafka setup and improve reliability. The most important changes include removing the separate controller service, consolidating controller roles into the broker services, adding health checks for brokers, and introducing new services for topic initialization and AKHQ.

Kafka setup improvements:

* Removed the separate controller service and consolidated the controller roles into the broker services.
* Added health checks for the broker services to ensure they are ready before proceeding.

New services:

* Introduced an `init-topics` service to automatically create necessary Kafka topics during startup.
* Added an `akhq` service to provide a web interface for managing Kafka clusters.